### PR TITLE
hosted clusters get route-monitor-operator and a console urlmonitor

### DIFF
--- a/deploy/acm-policies/60-hostedcluster-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/60-hostedcluster-route-monitor-operator.Policy.yaml
@@ -14,12 +14,22 @@ spec:
         kind: ConfigurationPolicy
         metadata:
           name: route-monitor-operator
-          namespace: openshift-route-monitor-operator
         spec:
-          namespaceSelector:
-            # pattern is "ocm-<staging|production>-<clusterid>-<clustername>"
-            include: ["ocm-*-*-*"]
-            exclude: []
+          remediationAction: enforce
+          object-templates:
+            # install route-monitor-operator
+            apiVersion: package-operator.run/v1alpha1
+            kind: ClusterPackage
+            metadata:
+                name: route-monitor-operator
+                spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: console-urlmonitor
+        spec:
           remediationAction: enforce
           object-templates:
             # the RouteMonitor to deploy

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5684,19 +5684,28 @@ objects:
             kind: ConfigurationPolicy
             metadata:
               name: route-monitor-operator
-              namespace: openshift-route-monitor-operator
             spec:
-              namespaceSelector:
-                include:
-                - ocm-*-*-*
-                exclude: []
+              remediationAction: enforce
+              object-templates:
+                apiVersion: package-operator.run/v1alpha1
+                kind: ClusterPackage
+                metadata:
+                  name: route-monitor-operator
+                  spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: console-urlmonitor
+            spec:
               remediationAction: enforce
               object-templates:
                 apiVersion: monitoring.openshift.io/v1alpha1
                 kind: RouteMonitor
                 metadata:
                   finalizers:
-                  - routeMonitor.routemonitoroperator.monitoring.openshift.io/finalizer
+                  - routemonitor.routemonitoroperator.monitoring.openshift.io/finalizer
                   labels:
                     hive.openshift.io/managed: 'true'
                   name: console
@@ -5705,7 +5714,7 @@ objects:
                     namespace: openshift-console
                     name: console
                   slo:
-                    targetAvailabilityPercent: "99.5"
+                    targetAvailabilityPercent: '99.5'
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5684,19 +5684,28 @@ objects:
             kind: ConfigurationPolicy
             metadata:
               name: route-monitor-operator
-              namespace: openshift-acm-policies
             spec:
-              namespaceSelector:
-                include:
-                - ocm-*-*-*
-                exclude: []
+              remediationAction: enforce
+              object-templates:
+                apiVersion: package-operator.run/v1alpha1
+                kind: ClusterPackage
+                metadata:
+                  name: route-monitor-operator
+                  spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: console-urlmonitor
+            spec:
               remediationAction: enforce
               object-templates:
                 apiVersion: monitoring.openshift.io/v1alpha1
                 kind: RouteMonitor
                 metadata:
                   finalizers:
-                  - routeMonitor.routemonitoroperator.monitoring.openshift.io/finalizer
+                  - routemonitor.routemonitoroperator.monitoring.openshift.io/finalizer
                   labels:
                     hive.openshift.io/managed: 'true'
                   name: console
@@ -5705,7 +5714,7 @@ objects:
                     namespace: openshift-console
                     name: console
                   slo:
-                    targetAvailabilityPercent: "99.5"
+                    targetAvailabilityPercent: '99.5'
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5684,19 +5684,28 @@ objects:
             kind: ConfigurationPolicy
             metadata:
               name: route-monitor-operator
-              namespace: openshift-acm-policies
             spec:
-              namespaceSelector:
-                include:
-                - ocm-*-*-*
-                exclude: []
+              remediationAction: enforce
+              object-templates:
+                apiVersion: package-operator.run/v1alpha1
+                kind: ClusterPackage
+                metadata:
+                  name: route-monitor-operator
+                  spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: console-urlmonitor
+            spec:
               remediationAction: enforce
               object-templates:
                 apiVersion: monitoring.openshift.io/v1alpha1
                 kind: RouteMonitor
                 metadata:
                   finalizers:
-                  - routeMonitor.routemonitoroperator.monitoring.openshift.io/finalizer
+                  - routemonitor.routemonitoroperator.monitoring.openshift.io/finalizer
                   labels:
                     hive.openshift.io/managed: 'true'
                   name: console
@@ -5705,7 +5714,7 @@ objects:
                     namespace: openshift-console
                     name: console
                   slo:
-                    targetAvailabilityPercent: "99.5"
+                    targetAvailabilityPercent: '99.5'
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:


### PR DESCRIPTION
I renamed this file to avoid a conflict with the policy that will be resposnible for creating the api clusterurlmonitor on management clusters

This policy should now install the route-monitor-operator package and configure a urlmonitor for the cluster's console